### PR TITLE
Obtains the list of changed or added Company records since the last s…

### DIFF
--- a/src/develop/data/offline/patterns/read-only-data-optimized.md
+++ b/src/develop/data/offline/patterns/read-only-data-optimized.md
@@ -70,11 +70,11 @@ The following is a description of the logic of the `ServerDataSync` server actio
 1. Obtains the list of changed or added Company records since the last synchronization. The aggregate uses the following filter:
 
         Company.IsActive = True and
-        (Company.ModifiedOn = NullDate() or Company.ModifiedOn >= LastSync)
+        (Company.ModifiedOn = NullDate() or Company.ModifiedOn > LastSync)
 
 1. Obtains the list of all deleted (inactive) Company records since the last synchronization. The aggregate uses the following filter:
 
         Company.IsActive = False and
-        (Company.ModifiedOn = NullDate() or Company.ModifiedOn >= LastSync)
+        (Company.ModifiedOn = NullDate() or Company.ModifiedOn > LastSync)
 
 1. Assigns the timestamp and the two lists of Company records to the output parameters of the action.


### PR DESCRIPTION
…ynchronization

Assuming you are using datetime format for lastSync and for ModifiedOn, your precision is a second, a lot can happen inside a single second.

If you would use > instead of >=, then the records you would potentially loose, are those that were created in the same second like the lastSync, but after the LastSync was finished.